### PR TITLE
Added AW_Autorelated - SQL injection

### DIFF
--- a/magento1-vulnerable-extensions.csv
+++ b/magento1-vulnerable-extensions.csv
@@ -21,6 +21,7 @@ Amasty_Table,2.5.4,,,https://amasty.com/shipping-table-rates.html
 AW_Advancednewsletter,2.3.5,,https://labs.integrity.pt/advisories/cve-2014-1634/index.html,https://ecommerce.aheadworks.com/magento-extensions/advanced-newsletter.html
 AW_Advancedreports,2.8.2,/advancedreports/chart/tunnel/,https://www.facebook.com/Aheadworks/photos/notice-we-fixed-the-vulnerability-connected-with-php-object-injection-discovered/2126624844064804/,https://ecommerce.aheadworks.com/magento-extensions/advanced-reports.html
 AW_AheadMetrics,,/aheadmetrics/auth/index/,https://gwillem.gitlab.io/2018/10/23/magecart-extension-0days/,Abandoned
+AW_Autorelated,,/admin_awautorelated/adminhtml_blocksgrid/massStatus,Martien Mortiaux (AlterWeb),
 AW_Blog,1.3.18,,https://ecommerce.aheadworks.com/magento-extension-updates/blog.html,https://ecommerce.aheadworks.com/magento-extensions/blog.html
 AW_Followupemail,3.6.6,,https://blog.aheadworks.com/security-issue-follow-up-email-vulnerability/,https://ecommerce.aheadworks.com/magento-extensions/follow-up-email.html
 BSS_ReorderProduct,1.2.4,/bssreorderproduct/list/add/,https://gwillem.gitlab.io/2018/10/23/magecart-extension-0days/,https://bsscommerce.com/magento-reorder-product-extension.html

--- a/magento1-vulnerable-extensions.csv
+++ b/magento1-vulnerable-extensions.csv
@@ -21,7 +21,7 @@ Amasty_Table,2.5.4,,,https://amasty.com/shipping-table-rates.html
 AW_Advancednewsletter,2.3.5,,https://labs.integrity.pt/advisories/cve-2014-1634/index.html,https://ecommerce.aheadworks.com/magento-extensions/advanced-newsletter.html
 AW_Advancedreports,2.8.2,/advancedreports/chart/tunnel/,https://www.facebook.com/Aheadworks/photos/notice-we-fixed-the-vulnerability-connected-with-php-object-injection-discovered/2126624844064804/,https://ecommerce.aheadworks.com/magento-extensions/advanced-reports.html
 AW_AheadMetrics,,/aheadmetrics/auth/index/,https://gwillem.gitlab.io/2018/10/23/magecart-extension-0days/,Abandoned
-AW_Autorelated,,/admin_awautorelated/adminhtml_blocksgrid/massStatus,https://www.alterweb.nl/blog/aheadworks-autorelated-security-issue,https://www.alterweb.nl/blog/aheadworks-autorelated-security-issue
+AW_Autorelated,,/admin_awautorelated/adminhtml_blocksgrid/massStatus,https://www.alterweb.nl/blog/aheadworks-autorelated-security-issue,https://ecommerce.aheadworks.com/magento-extension-updates/automatic-related-products-2.html
 AW_Blog,1.3.18,,https://ecommerce.aheadworks.com/magento-extension-updates/blog.html,https://ecommerce.aheadworks.com/magento-extensions/blog.html
 AW_Followupemail,3.6.6,,https://blog.aheadworks.com/security-issue-follow-up-email-vulnerability/,https://ecommerce.aheadworks.com/magento-extensions/follow-up-email.html
 BSS_ReorderProduct,1.2.4,/bssreorderproduct/list/add/,https://gwillem.gitlab.io/2018/10/23/magecart-extension-0days/,https://bsscommerce.com/magento-reorder-product-extension.html

--- a/magento1-vulnerable-extensions.csv
+++ b/magento1-vulnerable-extensions.csv
@@ -21,7 +21,7 @@ Amasty_Table,2.5.4,,,https://amasty.com/shipping-table-rates.html
 AW_Advancednewsletter,2.3.5,,https://labs.integrity.pt/advisories/cve-2014-1634/index.html,https://ecommerce.aheadworks.com/magento-extensions/advanced-newsletter.html
 AW_Advancedreports,2.8.2,/advancedreports/chart/tunnel/,https://www.facebook.com/Aheadworks/photos/notice-we-fixed-the-vulnerability-connected-with-php-object-injection-discovered/2126624844064804/,https://ecommerce.aheadworks.com/magento-extensions/advanced-reports.html
 AW_AheadMetrics,,/aheadmetrics/auth/index/,https://gwillem.gitlab.io/2018/10/23/magecart-extension-0days/,Abandoned
-AW_Autorelated,,/admin_awautorelated/adminhtml_blocksgrid/massStatus,Martien Mortiaux (AlterWeb),
+AW_Autorelated,,/admin_awautorelated/adminhtml_blocksgrid/massStatus,https://www.alterweb.nl/blog/aheadworks-autorelated-security-issue,https://www.alterweb.nl/blog/aheadworks-autorelated-security-issue
 AW_Blog,1.3.18,,https://ecommerce.aheadworks.com/magento-extension-updates/blog.html,https://ecommerce.aheadworks.com/magento-extensions/blog.html
 AW_Followupemail,3.6.6,,https://blog.aheadworks.com/security-issue-follow-up-email-vulnerability/,https://ecommerce.aheadworks.com/magento-extensions/follow-up-email.html
 BSS_ReorderProduct,1.2.4,/bssreorderproduct/list/add/,https://gwillem.gitlab.io/2018/10/23/magecart-extension-0days/,https://bsscommerce.com/magento-reorder-product-extension.html


### PR DESCRIPTION
I found a security issue in the AheadWorks Automatic Related Products module where you can inject SQL. I tested it on multiple Magento installations and multiple versions of this module (since 2.4.2 released at least 4.5 years ago) including the latest version (2.5.0).

I reported this issue to AheadWorks. Once AheadWorks releases a patched version I will add it's version number and change the url for upgrade instructions.