### PR TITLE
Added Commerce Extensions import / export modules

### DIFF
--- a/magento1-vulnerable-extensions.csv
+++ b/magento1-vulnerable-extensions.csv
@@ -21,6 +21,7 @@ Amasty_Table,2.5.4,,,https://amasty.com/shipping-table-rates.html
 AW_Advancednewsletter,2.3.5,,https://labs.integrity.pt/advisories/cve-2014-1634/index.html,https://ecommerce.aheadworks.com/magento-extensions/advanced-newsletter.html
 AW_Advancedreports,2.8.2,/advancedreports/chart/tunnel/,https://www.facebook.com/Aheadworks/photos/notice-we-fixed-the-vulnerability-connected-with-php-object-injection-discovered/2126624844064804/,https://ecommerce.aheadworks.com/magento-extensions/advanced-reports.html
 AW_AheadMetrics,,/aheadmetrics/auth/index/,https://gwillem.gitlab.io/2018/10/23/magecart-extension-0days/,Abandoned
+AW_Autorelated,,/admin_awautorelated/adminhtml_blocksgrid/massStatus,Martien Mortiaux (AlterWeb),
 AW_Blog,1.3.18,,https://ecommerce.aheadworks.com/magento-extension-updates/blog.html,https://ecommerce.aheadworks.com/magento-extensions/blog.html
 AW_Followupemail,3.6.6,,https://blog.aheadworks.com/security-issue-follow-up-email-vulnerability/,https://ecommerce.aheadworks.com/magento-extensions/follow-up-email.html
 BSS_ReorderProduct,1.2.4,/bssreorderproduct/list/add/,https://gwillem.gitlab.io/2018/10/23/magecart-extension-0days/,https://bsscommerce.com/magento-reorder-product-extension.html

--- a/magento1-vulnerable-extensions.csv
+++ b/magento1-vulnerable-extensions.csv
@@ -21,7 +21,7 @@ Amasty_Table,2.5.4,,,https://amasty.com/shipping-table-rates.html
 AW_Advancednewsletter,2.3.5,,https://labs.integrity.pt/advisories/cve-2014-1634/index.html,https://ecommerce.aheadworks.com/magento-extensions/advanced-newsletter.html
 AW_Advancedreports,2.8.2,/advancedreports/chart/tunnel/,https://www.facebook.com/Aheadworks/photos/notice-we-fixed-the-vulnerability-connected-with-php-object-injection-discovered/2126624844064804/,https://ecommerce.aheadworks.com/magento-extensions/advanced-reports.html
 AW_AheadMetrics,,/aheadmetrics/auth/index/,https://gwillem.gitlab.io/2018/10/23/magecart-extension-0days/,Abandoned
-AW_Autorelated,,/admin_awautorelated/adminhtml_blocksgrid/massStatus,https://www.alterweb.nl/blog/aheadworks-autorelated-security-issue,https://www.alterweb.nl/blog/aheadworks-autorelated-security-issue
+AW_Autorelated,,/admin_awautorelated/adminhtml_blocksgrid/massStatus,https://www.alterweb.nl/blog/aheadworks-autorelated-security-issue,https://ecommerce.aheadworks.com/magento-extension-updates/automatic-related-products-2.html
 AW_Blog,1.3.18,,https://ecommerce.aheadworks.com/magento-extension-updates/blog.html,https://ecommerce.aheadworks.com/magento-extensions/blog.html
 AW_Followupemail,3.6.6,,https://blog.aheadworks.com/security-issue-follow-up-email-vulnerability/,https://ecommerce.aheadworks.com/magento-extensions/follow-up-email.html
 BSS_ReorderProduct,1.2.4,/bssreorderproduct/list/add/,https://gwillem.gitlab.io/2018/10/23/magecart-extension-0days/,https://bsscommerce.com/magento-reorder-product-extension.html

--- a/magento1-vulnerable-extensions.csv
+++ b/magento1-vulnerable-extensions.csv
@@ -28,6 +28,8 @@ BSS_ReorderProduct,1.2.4,/bssreorderproduct/list/add/,https://gwillem.gitlab.io/
 BusinessKing_OutofStockSubscription,1.2.1,/outofstocksubscription/,roland@magehost.pro,http://www.businessapplicationking.com/product-out-of-stock-subscription.html
 Campaigner,1.1.6,/emaildirect/abandoned/restore/,https://gwillem.gitlab.io/2018/10/23/magecart-extension-0days/,
 Ced_Layaway,,/layaway/view/add/,https://gwillem.gitlab.io/2018/10/23/magecart-extension-0days/,Abandoned
+CommerceExtensions_Categoriesimportexport,,/categoriesimportexport/,https://www.alterweb.nl/techtalk/commerce-extensions-import-export-security-issue,https://www.commerceextensions.com/magento-bulk-categories-import-export-csv-xml.html
+CommerceExtensions_Advancedcustomerimportexport,,/advancedcustomerimportexport/,https://www.alterweb.nl/techtalk/commerce-extensions-import-export-security-issue,https://www.commerceextensions.com/advanced-customer-import-export-csv-xml.html
 CommerceLab_News,,/clnews/,https://www.magecloud.net/marketplace/extension/news-by-commercelab/,
 CommerceLab_GreatNews,,/clnews/,https://www.magecloud.net/marketplace/extension/news-by-commercelab/,
 CommerceThemes_GuestToReg,,/GuestToReg/index/post/,https://twitter.com/gwillem/status/1065986386795380736,Abandoned

--- a/magento1-vulnerable-extensions.csv
+++ b/magento1-vulnerable-extensions.csv
@@ -21,7 +21,7 @@ Amasty_Table,2.5.4,,,https://amasty.com/shipping-table-rates.html
 AW_Advancednewsletter,2.3.5,,https://labs.integrity.pt/advisories/cve-2014-1634/index.html,https://ecommerce.aheadworks.com/magento-extensions/advanced-newsletter.html
 AW_Advancedreports,2.8.2,/advancedreports/chart/tunnel/,https://www.facebook.com/Aheadworks/photos/notice-we-fixed-the-vulnerability-connected-with-php-object-injection-discovered/2126624844064804/,https://ecommerce.aheadworks.com/magento-extensions/advanced-reports.html
 AW_AheadMetrics,,/aheadmetrics/auth/index/,https://gwillem.gitlab.io/2018/10/23/magecart-extension-0days/,Abandoned
-AW_Autorelated,,/admin_awautorelated/adminhtml_blocksgrid/massStatus,Martien Mortiaux (AlterWeb),
+AW_Autorelated,,/admin_awautorelated/adminhtml_blocksgrid/massStatus,https://www.alterweb.nl/blog/aheadworks-autorelated-security-issue,https://www.alterweb.nl/blog/aheadworks-autorelated-security-issue
 AW_Blog,1.3.18,,https://ecommerce.aheadworks.com/magento-extension-updates/blog.html,https://ecommerce.aheadworks.com/magento-extensions/blog.html
 AW_Followupemail,3.6.6,,https://blog.aheadworks.com/security-issue-follow-up-email-vulnerability/,https://ecommerce.aheadworks.com/magento-extensions/follow-up-email.html
 BSS_ReorderProduct,1.2.4,/bssreorderproduct/list/add/,https://gwillem.gitlab.io/2018/10/23/magecart-extension-0days/,https://bsscommerce.com/magento-reorder-product-extension.html


### PR DESCRIPTION
I found a security issue with (I think) all of the import / export modules from Commerce Extensions a while back. The modules we used where fixed by them and I guess so did the rest but they got the same version number witch means I can not give a version number where they where fixed. I only had access to the two modules that I listed here but there are lots more and I'm almost sure they all had the same issue (see https://www.commerceextensions.com/magento-extensions.html). I can guess the module names and front names for them but am not 100% sure so I did not add them. 

I don't know if I have to make an issue for this but if any of you have access to more import / export modules from this module maker please check if the same issue exist and report the module names and front names (url) they use.