### PR TITLE
Added Addonline_SoColissimo

### DIFF
--- a/magento1-vulnerable-extensions.csv
+++ b/magento1-vulnerable-extensions.csv
@@ -1,4 +1,5 @@
 Name,Fixed in,Relevant URI,Reference,Update URL
+Addonline_SoColissimo,,/socolissimo/ajax/getcitynamebyzipcode/,https://twitter.com/gwillem/status/1121397274041638913,http://www.modules-ecommerce.fr
 Amasty_Acart,1.17.4,,,https://amasty.com/magento-abandoned-cart-email.html
 Amasty_Blog,2.3.4,,,https://amasty.com/magento-blog-pro.html
 Amasty_Customform,1.7.3,,,https://amasty.com/magento-form-builder.html


### PR DESCRIPTION
Discovered by @avstudnitz. Actual abuse observed.

Vuln version: 2.1.1
Vuln code:
```
$zipcode = $this->getRequest()->getParam('zipcode', false);
$country = $this->getRequest()->getParam('country', false);  
$this->_connectionRead = Mage::getSingleton('core/resource')->getConnection('core_read');
$sqlResults = $this->_connectionRead->fetchAll("SELECT city_name as placeName FROM " . Mage::getSingleton('core/resource')->getTableName('socolissimo_cities') . " WHERE country = '" . $country . "' and city_zipcode = '" . $zipcode . "';");
```
Vendor prod@addonline.fr mailed march 29th, no reply.
No online updates available.
