### PR TITLE
Update fixed version number for Addonline_SoColissimo

### DIFF
--- a/magento1-vulnerable-extensions.csv
+++ b/magento1-vulnerable-extensions.csv
@@ -1,5 +1,5 @@
 Name,Fixed in,Relevant URI,Reference,Update URL
-Addonline_SoColissimo,,/socolissimo/ajax/getcitynamebyzipcode/,https://twitter.com/gwillem/status/1121397274041638913,http://www.modules-ecommerce.fr
+Addonline_SoColissimo,2.2.1,/socolissimo/ajax/getcitynamebyzipcode/,https://twitter.com/gwillem/status/1121397274041638913,http://www.modules-ecommerce.fr
 Amasty_Acart,1.17.4,,,https://amasty.com/magento-abandoned-cart-email.html
 Amasty_Blog,2.3.4,,,https://amasty.com/magento-blog-pro.html
 Amasty_Customform,1.7.3,,,https://amasty.com/magento-form-builder.html


### PR DESCRIPTION
twitter.com/Acyba writes:

> We've released a lot of new version since this one. This has been released in version 2.2.1
> Unfortunately this is not available anymore as we stopped the plug-in development and we had to remove it from our website (La Poste asked us to do so)