### PR TITLE
Mirasvit_Helpdesk vulnerable up to version 1.5.14

### DIFF
--- a/magento1-vulnerable-extensions.csv
+++ b/magento1-vulnerable-extensions.csv
@@ -63,8 +63,8 @@ Magmi,0.7.22,/magmi/,http://magmi.org/magmi-security-issue-solved/,http://wiki.m
 Magpleasure_Common,0.8.13,/admin/magpleasure/ajaxform/save/,https://www.alterweb.nl/techtalk/magpleasure_common-security-issue,Abandoned
 Magpleasure_Filesystem,,,http://www.magpleasure.com/blog/quick-survey-should-we-leave-the-file-system-extension-alive.html,
 MD_Quickview,,,https://magento.com/security/vulnerabilities/sql-injection-vulnerability,
-Mirasvit_Helpdesk,1.5.14,,https://mirasvit.com/doc/extension_helpdesk/current/changelog,https://mirasvit.com/magento-extensions/helpdesk.html
-Mirasvit_SEO,1.3.16,,https://mirasvit.com/doc/extension_seosuite/current/changelog,https://mirasvit.com/magento-extensions/advanced-seo-suite.html
+_Mirasvit_Helpdesk,1.5.14,,https://mirasvit.com/doc/extension_helpdesk/current/changelog,https://mirasvit.com/magento-extensions/helpdesk.html
+_Mirasvit_SEO,1.3.16,,https://mirasvit.com/doc/extension_seosuite/current/changelog,https://mirasvit.com/magento-extensions/advanced-seo-suite.html
 MW_Affiliate,,mw_aref=,martin@magemojo.com to gwillem@gmail.com,
 Netgo_Gwishlist,,/netgocust/Gwishlist/updategwishlist/,https://gwillem.gitlab.io/2018/10/23/magecart-extension-0days/,https://github.com/wesleyalmd/mageGwishlist/
 Ophira_Qquoteadv,5.4.5,/qquoteadv/download/downloadCustomOption/,https://cart2quote.zendesk.com/hc/en-us/articles/115000616303--FIXED-Security-Vulnerability-in-downloadCustomOptionAction,https://www.cart2quote.com/

--- a/magento1-vulnerable-extensions.csv
+++ b/magento1-vulnerable-extensions.csv
@@ -63,7 +63,7 @@ Magmi,0.7.22,/magmi/,http://magmi.org/magmi-security-issue-solved/,http://wiki.m
 Magpleasure_Common,0.8.13,/admin/magpleasure/ajaxform/save/,https://www.alterweb.nl/techtalk/magpleasure_common-security-issue,Abandoned
 Magpleasure_Filesystem,,,http://www.magpleasure.com/blog/quick-survey-should-we-leave-the-file-system-extension-alive.html,
 MD_Quickview,,,https://magento.com/security/vulnerabilities/sql-injection-vulnerability,
-Mirasvit_Helpdesk,1.5.3,,https://mirasvit.com/blog/helpdesk-mx-for-magento-1-security-issue.html,https://mirasvit.com/magento-extensions/helpdesk.html
+Mirasvit_Helpdesk,1.5.14,,https://mirasvit.com/doc/extension_helpdesk/current/changelog,https://mirasvit.com/magento-extensions/helpdesk.html
 Mirasvit_SEO,1.3.16,,https://mirasvit.com/doc/extension_seosuite/current/changelog,https://mirasvit.com/magento-extensions/advanced-seo-suite.html
 MW_Affiliate,,mw_aref=,martin@magemojo.com to gwillem@gmail.com,
 Netgo_Gwishlist,,/netgocust/Gwishlist/updategwishlist/,https://gwillem.gitlab.io/2018/10/23/magecart-extension-0days/,https://github.com/wesleyalmd/mageGwishlist/


### PR DESCRIPTION
There was no security announcement, but Mirasvit_Helpdesk has a "possible XSS security issue" up to 1.5.14: https://mirasvit.com/doc/extension_helpdesk/current/changelog

Note that MageVulnDb may report an older version for Mirasvit_Helpdesk than you actually have installed because a new marketing version might not trigger a change in `config.xml`. For example, marketing version 1.5.11 has the XML config entry `<version>1.0.36</version>`.

I will update this issue when I know if 1.5.14 has a newer XML config version.