### PR TITLE
Added initial known-vulnerable M2 modules (#37)

### DIFF
--- a/magento2-vulnerable-extensions.csv
+++ b/magento2-vulnerable-extensions.csv
@@ -5,10 +5,10 @@ Amasty_Shopby,2.10.5,,Francis M. Gallagher,https://amasty.com/improved-layered-n
 Amasty_Storelocator,1.4.7,,Francis M. Gallagher,https://amasty.com/store-locator-for-magento-2.html
 Amasty_Storeswitcher?,1.0.13,,,https://amasty.com/store-switcher-for-magento-2.html
 AW_Blog,2.4.6,,https://ecommerce.aheadworks.com/magento-extension-updates/blog,https://ecommerce.aheadworks.com/magento-2-extensions/blog
-Campaigner_Integration,?,,Max Chadwick,?
+Campaigner_Integration,,,Max Chadwick,
 Fooman_PdfCustomiser,8.1.8,,https://twitter.com/foomanNZ/status/1118496841488748546,
 Fooman_Tcpdf,6.2.25.2,,,https://mailchi.mp/fooman/important-security-update-for-pdf-customiser-3218933
-Mageplaza_LayeredNavigation,?,,John Knowles,https://www.mageplaza.com/magento-2-layered-navigation-extension/
+Mageplaza_LayeredNavigation,,,John Knowles,https://www.mageplaza.com/magento-2-layered-navigation-extension/
 Magestore_Storelocator,1.0.2,,,https://blog.magestore.com/store-locator-extension-patch/
 Magestore_Storepickup,1.2.1,,,https://blog.magestore.com/store-locator-extension-patch/
 Mirasvit_Blog,1.0.21,,,https://github.com/mirasvit/module-blog

--- a/magento2-vulnerable-extensions.csv
+++ b/magento2-vulnerable-extensions.csv
@@ -1,1 +1,13 @@
 Name,Fixed in,Relevant URI,Reference,Update URL
+Amasty_Adminbookmarks?,1.0.5,,,https://amasty.com/magento-admin-bookmarks-for-magento-2.html
+Amasty_GeoipRedirect,1.0.18,,,https://amasty.com/geoip-redirect-for-magento-2.html
+Amasty_Shopby,2.10.5,,Francis M. Gallagher,https://amasty.com/improved-layered-navigation-for-magento-2.html
+Amasty_Storelocator,1.4.7,,Francis M. Gallagher,https://amasty.com/store-locator-for-magento-2.html
+Amasty_Storeswitcher?,1.0.13,,,https://amasty.com/store-switcher-for-magento-2.html
+AW_Blog,2.4.6,,https://ecommerce.aheadworks.com/magento-extension-updates/blog,https://ecommerce.aheadworks.com/magento-2-extensions/blog
+Campaigner_Integration,?,,Max Chadwick,?
+Fooman_PdfCustomiser,8.1.8,,https://twitter.com/foomanNZ/status/1118496841488748546,
+Fooman_Tcpdf,6.2.25.2,,,https://mailchi.mp/fooman/important-security-update-for-pdf-customiser-3218933
+Mageplaza_LayeredNavigation,?,,John Knowles,https://www.mageplaza.com/magento-2-layered-navigation-extension/
+Magestore_Storelocator,1.0.2,,,https://blog.magestore.com/store-locator-extension-patch/
+Magestore_Storepickup,1.2.1,,,https://blog.magestore.com/store-locator-extension-patch/

--- a/magento2-vulnerable-extensions.csv
+++ b/magento2-vulnerable-extensions.csv
@@ -11,3 +11,5 @@ Fooman_Tcpdf,6.2.25.2,,,https://mailchi.mp/fooman/important-security-update-for-
 Mageplaza_LayeredNavigation,?,,John Knowles,https://www.mageplaza.com/magento-2-layered-navigation-extension/
 Magestore_Storelocator,1.0.2,,,https://blog.magestore.com/store-locator-extension-patch/
 Magestore_Storepickup,1.2.1,,,https://blog.magestore.com/store-locator-extension-patch/
+Mirasvit_Blog,1.0.21,,,https://github.com/mirasvit/module-blog
+Mirasvit_Giftr,1.2.16,,,https://mirasvit.com/magento-2-extensions/gift-registry.html


### PR DESCRIPTION
From https://github.com/gwillem/magevulndb/issues/37

Initial build out of the M2 vulnerable modules list. I pieced together info we've been given best I could.

Before merging, if possible:
- [ ] Need confirmation on module tags: Amasty_Adminbookmarks, Amasty_GeoipRedirect, Amasty_Storeswitcher
- [ ] Need additional info on Campaigner_Integration (version, URL) @mpchadwick 
- [ ] Need version for Mageplaza_LayeredNavigation @gwillem 

Any attack URI info for any of the listed would also help -- and of course any additions are welcome.