### PR TITLE
Set exit code 0 for potentially vulnerable modules (fixes #39)

### DIFF
--- a/src/ModuleBlacklist/Magerun/SecurityScanCommand.php
+++ b/src/ModuleBlacklist/Magerun/SecurityScanCommand.php
@@ -58,8 +58,10 @@ class SecurityScanCommand extends AbstractMagentoCommand
             }
 
             while ($row = $this->getRowObject(fgetcsv($blacklist))) {
-                if ($this->checkIsInstalledModule($output, $row) || $this->checkIsInstalledRoute($output, $row)) {
+                if ($this->checkIsInstalledModule($output, $row)) {
                     $hitCount++;
+                } else {
+                    $this->checkIsInstalledRoute($output, $row);
                 }
             }
 
@@ -79,7 +81,7 @@ class SecurityScanCommand extends AbstractMagentoCommand
      *
      * @param \Symfony\Component\Console\Output\OutputInterface $output
      * @param \Varien_Object $row
-     * @return int
+     * @return bool
      */
     protected function checkIsInstalledModule(OutputInterface $output, \Varien_Object $row)
     {
@@ -135,7 +137,7 @@ class SecurityScanCommand extends AbstractMagentoCommand
 
         $output->writeln(
             sprintf(
-                '<error>Potential vulnerable module found: %s%s</error>',
+                '<comment>Potential vulnerable module found: %s%s</comment>',
                 $module,
                 $output->isQuiet() ? sprintf(' (route match: %s)', $row->getFrontname()) : ''
             ),

--- a/src/ModuleBlacklist/Magerun2/SecurityScanCommand.php
+++ b/src/ModuleBlacklist/Magerun2/SecurityScanCommand.php
@@ -102,9 +102,11 @@ class SecurityScanCommand extends AbstractMagentoCommand
         }
 
         foreach ($this->blacklist->getEntries() as $entry) {
-            if ($this->reportVulnerableModule($output, $entry) || $this->reportVulnerableRoute($output, $entry)) {
+            if ($this->reportVulnerableModule($output, $entry)) {
                 $hitCount++;
-            }   
+            } else {
+                $this->reportVulnerableRoute($output, $entry);
+            }
         }
 
         if ($hitCount === 0) {
@@ -120,7 +122,7 @@ class SecurityScanCommand extends AbstractMagentoCommand
      *
      * @param OutputInterface $output
      * @param Entry $entry
-     * @return int
+     * @return bool
      */
     protected function reportVulnerableModule(OutputInterface $output, Entry $entry)
     {
@@ -179,7 +181,7 @@ class SecurityScanCommand extends AbstractMagentoCommand
 
         $output->writeln(
             sprintf(
-                '<error>Potential vulnerable module found: %s%s</error>',
+                '<comment>Potential vulnerable module found: %s%s</comment>',
                 $module,
                 $output->isQuiet() ? sprintf(' (route match: %s)', $entry->getFrontname()) : ''
             ),


### PR DESCRIPTION
I tried to do a small change to the logic only.

Changes:
- when there are only potentially vulnerable modules (no known vulnerable modules), exit with status code 0 instead of 1
- use "info" style for message "Potential vulnerable module found: Foo_Bar" to differentiate from real errors. This results in a yellow-ish line, looking more like a warning (there is no `<warning>` for Symfony console output AFAIK).

Output and behaviour for known vulnerable modules stays the same.