### PR TITLE
Add Mico_Upload

### DIFF
--- a/magento1-vulnerable-extensions.csv
+++ b/magento1-vulnerable-extensions.csv
@@ -65,7 +65,7 @@ Magmi,0.7.22,/magmi/,http://magmi.org/magmi-security-issue-solved/,http://wiki.m
 Magpleasure_Common,0.8.13,/admin/magpleasure/ajaxform/save/,https://www.alterweb.nl/techtalk/magpleasure_common-security-issue,Abandoned
 Magpleasure_Filesystem,,,http://www.magpleasure.com/blog/quick-survey-should-we-leave-the-file-system-extension-alive.html,
 MD_Quickview,,,https://magento.com/security/vulnerabilities/sql-injection-vulnerability,
-Mico_Mupload,,/mupload/uploader/save,,https://www.micosolutions.com/upload-ultimate-for-magento
+Mico_Mupload,,/mupload/uploader/save,https://github.com/gwillem/magevulndb/pull/72,https://www.micosolutions.com/upload-ultimate-for-magento
 _Mirasvit_Helpdesk,1.5.14,,https://mirasvit.com/doc/extension_helpdesk/current/changelog,https://mirasvit.com/magento-extensions/helpdesk.html
 _Mirasvit_SEO,1.3.16,,https://mirasvit.com/doc/extension_seosuite/current/changelog,https://mirasvit.com/magento-extensions/advanced-seo-suite.html
 MW_Affiliate,,mw_aref=,martin@magemojo.com to gwillem@gmail.com,

--- a/magento1-vulnerable-extensions.csv
+++ b/magento1-vulnerable-extensions.csv
@@ -65,6 +65,7 @@ Magmi,0.7.22,/magmi/,http://magmi.org/magmi-security-issue-solved/,http://wiki.m
 Magpleasure_Common,0.8.13,/admin/magpleasure/ajaxform/save/,https://www.alterweb.nl/techtalk/magpleasure_common-security-issue,Abandoned
 Magpleasure_Filesystem,,,http://www.magpleasure.com/blog/quick-survey-should-we-leave-the-file-system-extension-alive.html,
 MD_Quickview,,,https://magento.com/security/vulnerabilities/sql-injection-vulnerability,
+Mico_Mupload,,/mupload/uploader/save,,https://www.micosolutions.com/upload-ultimate-for-magento
 _Mirasvit_Helpdesk,1.5.14,,https://mirasvit.com/doc/extension_helpdesk/current/changelog,https://mirasvit.com/magento-extensions/helpdesk.html
 _Mirasvit_SEO,1.3.16,,https://mirasvit.com/doc/extension_seosuite/current/changelog,https://mirasvit.com/magento-extensions/advanced-seo-suite.html
 MW_Affiliate,,mw_aref=,martin@magemojo.com to gwillem@gmail.com,


### PR DESCRIPTION
Mico_Upload allows uploading of PHP code. It is exploited in the wild. 

Extension is encoded with IonCube. Vulnerability could be replicated using version 0.1.0. [Changelog](https://www.micosolutions.com/upload-ultimate-for-magento#changelog) does not mention security vulnerabilities so we have to assume the bug is present in the latest version. Vendor claims that the extension is not maintained anymore.